### PR TITLE
Use https URLs where possible

### DIFF
--- a/metadata_files/bis-rt-electricity-co2.json
+++ b/metadata_files/bis-rt-electricity-co2.json
@@ -38,7 +38,7 @@
         },
         "servers": [
           {
-            "url": "http://example.energydata.org.uk",
+            "url": "https://example.energydata.org.uk",
             "description": "Open Energy's Example Data Provider"
           }
         ],

--- a/metadata_files/bis-rt-electricity-kwh.yaml
+++ b/metadata_files/bis-rt-electricity-kwh.yaml
@@ -35,7 +35,7 @@
         description: CSV format data
         version: 0.1.0
       servers:
-        - url: 'http://example.energydata.org.uk'
+        - url: 'https://example.energydata.org.uk'
           description: Open Energy's Example Data Provider
       paths:
         /tidy_DYTS01_kWh:
@@ -79,7 +79,7 @@
         description: CSV format data
         version: 0.1.0
       servers:
-        - url: http://example.energydata.org.uk
+        - url: 'https://example.energydata.org.uk'
           description: Open Energy's Example Data Provider
       paths:
         "/tidy_DYTS02_kWh":


### PR DESCRIPTION
This avoids sending sensitive information such as Bearer Tokens over unencrypted http.